### PR TITLE
Fix compile bug

### DIFF
--- a/cvec.h
+++ b/cvec.h
@@ -8,10 +8,11 @@ typedef struct {
     size_t used;
 } vector_t;
 
+
 /* Attempts to grow [VECTOR] by [MORE]*/
 #define vector_try_grow(VECTOR, MORE) \
     (((!(VECTOR) || vector_meta(VECTOR)->used + (MORE) >= vector_meta(VECTOR)->allocated)) ? \
-        (void)vector_grow(((void **)&(VECTOR)), (MORE), sizeof(*(VECTOR))) : (void)0)
+        (void)vec_grow(((void **)&(VECTOR)), (MORE), sizeof(*(VECTOR))) : (void)0)
 
 /* Get the metadata block for [VECTOR] */
 #define vector_meta(VECTOR) \
@@ -19,7 +20,7 @@ typedef struct {
 
 /* Deletes [VECTOR] and sets it to NULL */
 #define vector_free(VECTOR) \
-    ((void)((VECTOR) ? (vector_delete((void *)(VECTOR)), (VECTOR) = NULL) : 0))
+    ((void)((VECTOR) ? (vec_delete((void *)(VECTOR)), (VECTOR) = NULL) : 0))
 
 /* Pushes back [VALUE] into [VECTOR] */
 #define vector_push(VECTOR, VALUE) \


### PR DESCRIPTION
Well I've looked at it more closely :)

So I can definitely appreciate the ease and syntax of using it and maybe I'll use it for some things but I still prefer mine and the structure/function method in general.

To sum up why I'll just quote from stretchy_buffer's comments

```
//    (There is no typesafe way to distinguish between stretchy
//    buffers and regular arrays/pointers; this is necessary to
//    make ordinary array indexing work on these objects.)
```

In other words, looking at a structure or function declaration there's no way to know
if it takes a regular pointer/array or a vector or not and the function itself can't tell.

Also, with mine I can trivially create a vector from any allocated array of the
same type and I can pass the array member to any function that takes that
type and they can do anything with it, including free or even realloc it
and it'll work.  They don't have to know about the vector type or do
anything special.

By having an actual vector type it's always obvious when something is
a vector.

The ease of modification/extension and debugging and such are just extra reasons but the above is the real reason.

Your method is more "typesafe" in its accesses than a generic vector of my style but it is less typesafe in terms of the vector itself.  This is worse imo as it more strongly affects the transparency of the code.  I can't quite think of a better way to describe it.  The syntax no longer reflects the semantics maybe?

And as I said, using cvector_void is the exception for when you only use it once and/or don't care about speed.  For any regular/serious use I'd always create a type specific vector.  

In the end it's just a matter of personal preference and being able to do this:

```
int** vec = NULL;
for (i=0; i<10; ++i) {
    vector_push(vec, NULL);
    for (j=0; j<10; ++j) {
        vector_push(vec[i], i*10+j);
    }
}
```

is really cool and way more convenient than the equivalent with my library.  Though admittedly I can't remember the last time I needed/wanted a vector of vectors.

For the simple case my version is as easy to use imo.

```
cvector_i vec = { 0 };
cvec_push_i(&vec, 100);
int ret = cvec_pop_i(&vec);
cvec_free_i(&vec);
```
